### PR TITLE
Avoid spurious comment highlighting

### DIFF
--- a/after/syntax/robot.vim
+++ b/after/syntax/robot.vim
@@ -74,8 +74,11 @@ syn match builtInLibrary            "\c\<\(Wait Until Keyword Succeeds\|Variable
 "------------------------------------------------------------------------
 " Regions
 "------------------------------------------------------------------------
-" Single-line comments. Are there multi-line comments?
-syn region robotComment     display start="#" excludenl end="$"
+" Comments are defined as: "All characters following the hash character (#),
+" when it is the first character of a cell". The start of a cell is either the
+" first non-whitespace content on a line or delimited either by two spaces or
+" a tab character.
+syn region robotComment     display start="\(^\|  \|\t\)[ \t]*#" excludenl end="$"
 syn region robotString      start="\"" excludenl end="\""
 
 "------------------------------------------------------------------------


### PR DESCRIPTION
The previous comment highlighting incorrectly highlighted the line following `#` characters occurring within a cell/token as comments, in cases such as `foo#bar` and `foo #bar`.

The `#bar` strings above should not be highlighted as comments, as they do not describe the start of a cell or token, which are delimited by at least either two spaces or a tab.

<http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#rules-for-parsing-the-data>

I removed the note on multiline comments, as they are not supported. See e.g.

* https://github.com/robotframework/robotframework/issues/1825
* https://groups.google.com/forum/#!topic/robotframework-users/yjgeHIcHfTs
* https://stackoverflow.com/q/26129435